### PR TITLE
New assembler flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,4 @@ centrifuge-build -p 10 --conversion-table seqid_to_taxid.map --taxonomy-tree nod
 
   - Guilhem Royer (CEA-Genoscope, now at Pasteur): design, implementation, evaluation
   - David Valllenet (CEA-Genoscope): design
+  - Julian Paganini (UMC Utrecht): new feature: accept unicycler assemblies

--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ Mode 1: SPAdes assembly + contig classification
   -2			reverse paired-end reads [MANDATORY]
 
 
-Mode 2: contig classification of a fasta file (only if you already have your SPAdes assembly!)
+Mode 2: contig classification of a fasta file (only if you already have your SPAdes or Unicycler assembly!)
   --fasta		SPAdes assembly fasta file [MANDATORY]
-
+  -a                    Specify the assembler used: spades or unicycler [MANDATORY]
 
 
 Example mode 1:
 plaScope.sh -1 my_reads_1.fastq.gz -2 my_reads_2.fastq.gz -o output_directory  --db_dir path/to/DB --db_name chromosome_plasmid_db --sample name_of_my_sample
 
 Example mode 2:
-plaScope.sh --fasta my_fastafile.fasta -o output_directory --db_dir path/to/DB --db_name chromosome_plasmid_db --sample name_of_my_sample
+plaScope.sh --fasta my_fastafile.fasta -o output_directory --db_dir path/to/DB --db_name chromosome_plasmid_db --sample name_of_my_sample -a unicycler
 
 
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Just create an account and launch the [PlaScope](https://biosphere.france-bioinf
 
 You can choose between two modes:
 * Mode 1: SPAdes assembly then contig classification
-* Mode 2: contig classification only (if you already assembled your genome with SPAdes)
+* Mode 2: contig classification only (if you already assembled your genome with SPAdes or Unicycler)
 
 ```bash
 $ ./plaScope.sh -h
@@ -89,7 +89,7 @@ Mode 1: SPAdes assembly + contig classification
 
 Mode 2: contig classification of a fasta file (only if you already have your SPAdes or Unicycler assembly!)
   --fasta		SPAdes assembly fasta file [MANDATORY]
-  -a                    Specify the assembler used: spades or unicycler [MANDATORY]
+  -a                    Specify the assembler used: spades or unicycler. Default=spades.
 
 
 Example mode 1:

--- a/plaScope.sh
+++ b/plaScope.sh
@@ -69,7 +69,7 @@ Example mode 1:
 plaScope.sh -1 my_reads_1.fastq.gz -2 my_reads_2.fastq.gz -o output_directory  --db_dir path/to/DB --db_name chromosome_plasmid_db --sample name_of_my_sample
 
 Example mode 2:
-plaScope.sh --fasta my_fastafile.fasta -o output_directory --db_dir path/to/DB --db_name chromosome_plasmid_db --sample name_of_my_sample
+plaScope.sh --fasta my_fastafile.fasta -o output_directory --db_dir path/to/DB --db_name chromosome_plasmid_db --sample name_of_my_sample -a unicycler
 
 
 

--- a/plaScope.sh
+++ b/plaScope.sh
@@ -22,7 +22,7 @@
 # Author Guilhem ROYER groyer@genoscope.cns.fr | 06/04/2018  #
 ##############################################################
 
-VERSION=1.3
+VERSION=1.3.1
 
 set -e
 set -u

--- a/plaScope.sh
+++ b/plaScope.sh
@@ -62,7 +62,7 @@ Mode 1: SPAdes assembly + contig classification
 
 Mode 2: contig classification of a fasta file (only if you already have your SPAdes or Unicycler assembly!)
   --fasta		SPAdes or Unicycler assembly fasta file [MANDATORY]
-  -a			Specify the assembler used: spades or unicycler [MANDATORY]
+  -a			Specify the assembler used: spades or unicycler. Default=spades.
 
 
 Example mode 1:
@@ -292,6 +292,9 @@ output { print >  output }' $contigsortingfile $contigfile
 ####################################
 #### Get argument with getopts #####
 ####################################
+
+#Establish default value for assembler
+assembler='spades'
 
 while getopts ":1:2:o:t:-:h:v:n:a:" optchar; do
 	case "${optchar}" in

--- a/plaScope.sh
+++ b/plaScope.sh
@@ -222,9 +222,6 @@ getline
 
 if ( $7>=contiglength && $6>=hitlength && ccov>contigcov )  print $1,TPLASCOPERES[$3]
 	
-#test if this could be fixed
-#if ( $6>=hitlength )  print $1,TPLASCOPERES[$3]
-
 else print $1,TPLASCOPERES[0]
 
 }' $plascopeextendres
@@ -255,9 +252,6 @@ getline
 {clab=$1; split(clab,T,"_") ; ccov=T[6];
 
 if ( $7>=contiglength && $6>=hitlength && ccov>contigcov )  print $1,TPLASCOPERES[$3]
-
-#test if this could be fixed
-#if ( $6>=hitlength )  print $1,TPLASCOPERES[$3]
 
 else print $1,TPLASCOPERES[0]
 


### PR DESCRIPTION
Added new flag '-a' for specifying assembler tool. Only unicycler or spades are available. 

If 'unicycler' is selected, coverage will not be used as a criteria for filtering potential contamination, since Unicycler already does a similar step.

